### PR TITLE
added support for HTTP Basic Authentication

### DIFF
--- a/spec/pinch_spec.rb
+++ b/spec/pinch_spec.rb
@@ -111,6 +111,28 @@ describe Pinch do
       end
     end
   end
+  
+  describe "when calling get on the example ZIP file behind HTTP Basic Authentication" do
+    before do
+      @url  = 'http://code.mrgossett.com/pinch_test.zip'
+      @file = 'data.json'
+      @data = "{\"gem\":\"pinch\",\"authors\":[\"Peter Hellberg\",\"Edward Patel\"],\"github_url\":\"https://github.com/peterhellberg/pinch\"}\n"
+    end
+
+    VCR.use_cassette('basic_auth', :match_requests_on => [:method, :uri, :headers]) do
+      it "should retrieve the contents of the file data.json with valid authentication" do
+        data = Pinch.get @url, @file, 'pinch_test', 'thisisjustatest'
+        data.must_equal @data
+        data.size.must_equal 114
+      end
+    
+      it "should not retrieve the contents of the file data.json with invalid authentication" do
+        lambda {
+          Pinch.get @url, @file, 'invalid_username', 'invalid_password'
+        }.must_raise Net::HTTPServerException
+      end
+    end
+  end
 
   describe "Pinch.file_list" do
     it "should return a list with all the file names in the ZIP file" do


### PR DESCRIPTION
Added support for HTTP Basic Authentication using two new optional attributes: `user` and `pass`:

```
Pinch.new('http://code.mrgossett.com/pinch_test.zip', 'pinch_test','thisisjustatest')
```

Also added a new method `#auth` that sets the username and password on a Pinch instance. `#auth` returns `self`, so it can be chained with other methods:

```
Pinch.new('http://code.mrgossett.com/pinch_test.zip').auth('pinch_test', 'thisisjustatest').get('data.json')
```

Added two spec tests to make sure it works with valid authentication and doesn't work with invalid authentication. All RSpec tests are passing.
