### PR TITLE
Don't require the Accept-Ranges header

### DIFF
--- a/lib/pinch.rb
+++ b/lib/pinch.rb
@@ -130,12 +130,6 @@ class Pinch
       # Raise exception if the response code isn’t in the 2xx range
       response.error! unless response.kind_of?(Net::HTTPSuccess)
 
-      # Raise exception if the server doesn’t support the Range header
-      unless (response['Accept-Ranges'] or "").include?('bytes')
-        raise RangeHeaderException,
-              "Range HTTP header not supported on #{@head_uri.host}"
-      end
-
       response['Content-Length'].to_i
     rescue Net::HTTPRetriableError => e
       @head_uri = URI.parse(e.response['Location'])
@@ -302,6 +296,5 @@ private
     http
   end
 
-  class RangeHeaderException < StandardError; end
   class TooManyRedirects < StandardError; end
 end

--- a/spec/pinch_spec.rb
+++ b/spec/pinch_spec.rb
@@ -30,17 +30,6 @@ end
 require File.dirname(__FILE__) + '/../lib/pinch'
 
 describe Pinch do
-  describe "url that redirects to the pinch zipball" do
-    it "should throw an exception about missing Range header support on GitHub" do
-      VCR.use_cassette('pinch_zipball') do
-        @url = 'https://github.com/peterhellberg/pinch/zipball/master'
-        lambda {
-          Pinch.file_list(@url)
-        }.must_raise Pinch::RangeHeaderException
-      end
-    end
-  end
-
   describe "when calling get on a compressed ZIP file" do
     it "should return the contents of the file" do
       VCR.use_cassette('squeak') do


### PR DESCRIPTION
According to the below, if partial content is supported on a server, this header is not required.

http://tools.ietf.org/html/rfc2616#section-14.5
https://tools.ietf.org/html/rfc7233#section-2.3

So in my interpretation, and according to the robustness principle, a client should not enforce the presence of the header.

We have encountered problems because of this with Microsoft Azure and Cachefly, which both seem to support range requests, but not always set the Accept-Ranges header.