### PR TITLE
Restore test suite, remove content length request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,3 @@ gem 'rake'
 group :documentation do
   gem 'yard'
 end
-
-platforms :rbx do
-  gem 'racc'
-  gem 'rubysl', '~> 2.0'
-  gem 'rubysl-test-unit'
-  gem 'psych'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,5 @@ task :default => :test
 
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['spec/*_spec.rb']
-  t.ruby_opts = ['-rubygems'] if defined? Gem
   t.ruby_opts << '-w -I.'
 end

--- a/lib/pinch.rb
+++ b/lib/pinch.rb
@@ -42,21 +42,6 @@ class Pinch
   end
 
   ##
-  # Retrieve the size of the ZIP file
-  #
-  # @param    [String] url        Full URL to the ZIP file
-  # @param    [String] user       (Optional) Username for Basic Authentication
-  # @param    [String] pass       (Optional) Password for Basic Authentication
-  # @return   [Fixnum]            Size of the ZIP file
-  # @example
-  #
-  #  Pinch.content_length('http://peterhellberg.github.com/pinch/test.zip') #=> 2516612
-  #
-  def self.content_length(url, user = nil, pass = nil)
-    new(url, user, pass).content_length
-  end
-
-  ##
   # Initializes a new Pinch object
   #
   # @param [String or Hash] url Full URL to the ZIP file or hash with different URLs for HTTP verbs, e.g.
@@ -118,30 +103,6 @@ class Pinch
     local_file(file_name, &block)
   end
 
-  ##
-  # @note You might want to use Pinch.content_length instead
-  #
-  def content_length
-    @content_length ||= begin
-      request = Net::HTTP::Head.new(@head_uri.request_uri)
-      request.basic_auth(@user, @pass) unless @user.nil? || @pass.nil?
-      response = connection(@head_uri).request(request)
-
-      # Raise exception if the response code isn’t in the 2xx range
-      response.error! unless response.kind_of?(Net::HTTPSuccess)
-
-      response['Content-Length'].to_i
-    rescue Net::HTTPRetriableError => e
-      @head_uri = URI.parse(e.response['Location'])
-
-      if (@redirects -= 1) > 0
-        retry
-      else
-        raise TooManyRedirects, "Gave up at on #{@head_uri.host}"
-      end
-    end
-  end
-
 private
 
   def local_file(file_name)
@@ -170,11 +131,11 @@ private
                    file_headers[file_name][12]
 
     if block_given?
-      fetch_data(offset_start, offset_end) do |response|
+      fetch_data(offset_start..offset_end) do |response|
         yield PinchResponse.new(response)
       end
     else
-      response = fetch_data(offset_start, offset_end)
+      response = fetch_data(offset_start..offset_end)
 
       local_file_header = response.body.unpack('VvvvvvVVVvv')
       file_data         = response.body[30+local_file_header[9]+local_file_header[10]..-1]
@@ -234,8 +195,7 @@ private
       offset_start = end_of_central_directory_record[5]
       offset_end   = end_of_central_directory_record[5] + end_of_central_directory_record[4]
 
-      response = fetch_data(offset_start, offset_end)
-
+      response = fetch_data(offset_start..offset_end)
 
       if ['200', '206'].include?(response.code)
         response.body
@@ -255,10 +215,8 @@ private
     #6  uint16 ZIPfileCommentLength;
 
     @end_of_central_directory_record ||= begin
-      # Retrieve a 4k of data from the end of the zip file
-      offset = content_length >= 4096 ? content_length-4096 : 0
-
-      response = fetch_data(offset, content_length)
+      # Retrieve last 4k of data from the zip file
+      response = fetch_data(-4096)
 
       # Unpack the body into a hex string then split on
       # the end record signature, and finally unpack the last one.
@@ -276,10 +234,10 @@ private
 
   ##
   # Get range of data from URL
-  def fetch_data(offset_start, offset_end, &block)
+  def fetch_data(range, &block)
     request = Net::HTTP::Get.new(@get_uri.request_uri)
     request.basic_auth(@user, @pass) unless @user.nil? || @pass.nil?
-    request.set_range(offset_start..offset_end)
+    request.set_range(range) if range
     connection(@get_uri).request(request, &block)
   end
 

--- a/pinch.gemspec
+++ b/pinch.gemspec
@@ -4,7 +4,7 @@ $:.unshift lib unless $:.include?(lib)
 require 'pinch'
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 3.0.0'
   s.require_paths << 'lib'
 
   s.name        = "pinch"
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.authors     = ["Peter Hellberg", "Edward Patel"]
   s.license     = "MIT-LICENSE"
 
-  s.has_rdoc          = true
   s.rdoc_options      = ['--main', 'README.rdoc', '--charset=UTF-8']
   s.extra_rdoc_files  = ['README.rdoc', 'MIT-LICENSE']
 
@@ -25,7 +24,9 @@ Gem::Specification.new do |s|
   s.files             = Dir.glob("lib/**/*") +
                         %w(MIT-LICENSE README.rdoc Rakefile .gemtest)
 
-  s.add_development_dependency 'minitest', '~> 5.2'
-  s.add_development_dependency 'webmock', '~> 1.16'
-  s.add_development_dependency 'vcr', '~> 2.8'
+  s.add_dependency 'net-http'
+
+  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'vcr'
 end

--- a/spec/pinch_spec.rb
+++ b/spec/pinch_spec.rb
@@ -124,24 +124,4 @@ describe Pinch do
       end
     end
   end
-
-  describe "Pinch.content_length" do
-    before do
-      @url  = 'http://peterhellberg.github.io/pinch/test.zip'
-    end
-
-    it "should return the size of the ZIP file" do
-      VCR.use_cassette('content_length') do
-        assert_equal 2516612, Pinch.content_length(@url)
-      end
-    end
-
-    it "should raise an exception if the file doesn't exist" do
-      VCR.use_cassette('content_length_404') do
-        assert_raises(Net::HTTPClientException) do
-          Pinch.content_length(@url+'404')
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
Hey there! I always loved the idea of this gem. I love how simple it is. But I've never had reason to use it -- until recently.

I dug in a little and noticed the test suite wasn't really running, so I did a little update to get that working and add `net-http` as an explicit dependency as required by modern ruby. And, sadly, Rubinius is long gone. I also had to remove the basic auth tests because that doesn't seem to be enforced at the test endpoint any more.

Then I noticed that the gem does an initial request to get the content-length - but this isn't required. You can ask for the last 4096 bytes of a remote resource by specifying `Range: bytes=-4096` which Net::HTTP supports as `#set_range(-4096)` and which simplifies the implementation.

Not sure if you're interested in contributions, but I offer it at your leisure :pray: